### PR TITLE
Update Octokit package to fix the API with GitHub

### DIFF
--- a/source/GitHubSearch.csproj
+++ b/source/GitHubSearch.csproj
@@ -45,8 +45,8 @@
       <HintPath>..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octokit, Version=0.27.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octokit.0.27.0\lib\net45\Octokit.dll</HintPath>
+    <Reference Include="Octokit, Version=0.29.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octokit.0.29.0\lib\net45\Octokit.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/source/packages.config
+++ b/source/packages.config
@@ -5,7 +5,7 @@
   <package id="FluentAssertions" version="4.14.0" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net452" />
-  <package id="Octokit" version="0.27.0" targetFramework="net452" />
+  <package id="Octokit" version="0.29.0" targetFramework="net452" />
   <package id="TinyIoC" version="1.3" targetFramework="net452" developmentDependency="true" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />

--- a/tests/GitHubSearch.Specs.csproj
+++ b/tests/GitHubSearch.Specs.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\FluentAssertions.4.14.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Octokit, Version=0.27.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octokit.0.27.0\lib\net45\Octokit.dll</HintPath>
+    <Reference Include="Octokit, Version=0.29.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octokit.0.29.0\lib\net45\Octokit.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FakeItEasy" version="2.2.0" targetFramework="net452" />
   <package id="FluentAssertions" version="4.14.0" targetFramework="net452" />
-  <package id="Octokit" version="0.27.0" targetFramework="net452" />
+  <package id="Octokit" version="0.29.0" targetFramework="net452" />
   <package id="xunit" version="2.1.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net452" />


### PR DESCRIPTION
After an update at GitHub, the GitHubSearch application could no longer communicate with GitHub.
Updating the Octokit package fixes this issue.